### PR TITLE
Implement matchweek system and post-draft tab visibility

### DIFF
--- a/AUTO_PICK_SYSTEM.md
+++ b/AUTO_PICK_SYSTEM.md
@@ -43,14 +43,23 @@ const allSelectedPlayerIds = Object.values(selectedPlayers)
 
 const available = availablePlayers.filter(p => !allSelectedPlayerIds.includes(p.id));
 
-// Pick a random player from top 10 available
-const randomPlayer = available[Math.floor(Math.random() * Math.min(10, available.length))];
+// Sort available players by fantasy points per game (highest first)
+const sortedByFantasyPoints = available.sort((a, b) => {
+  const aPoints = a.fantasy_points_per_game || 0;
+  const bPoints = b.fantasy_points_per_game || 0;
+  return bPoints - aPoints; // Descending order (highest first)
+});
+
+// Pick the player with the highest fantasy points per game
+const bestPlayer = sortedByFantasyPoints[0];
 ```
 
 **Smart Selection:**
-- Randomly selects from top 10 available players (not completely random)
+- Selects the player with the highest fantasy points per game
+- Uses fantasy points data to make optimal picks
 - Avoids picking already selected players
 - Falls back gracefully if no players available
+- Logs the selected player's fantasy points for transparency
 
 ## User Experience
 

--- a/backend/fantasy/urls.py
+++ b/backend/fantasy/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import user_leagues, league_teams, join_league, team_statistics, rugby_players, complete_draft, get_team_players, update_player_position, start_draft, get_draft_status, waiver_claims, process_waivers, trade_proposals, respond_to_trade, tournaments, chat_messages, chat_participants, update_read_status
+from .views import user_leagues, league_teams, join_league, team_statistics, rugby_players, complete_draft, get_team_players, update_player_position, start_draft, get_draft_status, waiver_claims, process_waivers, trade_proposals, respond_to_trade, tournaments, chat_messages, chat_participants, update_read_status, tournament_availability, league_fixtures, next_matchup
 from .admin_views import remove_team_from_league, get_league_admin, is_user_league_admin
 from .authentication import register, login, refresh_token, verify_token, logout
 from .views.draft_views import debug_database
@@ -12,6 +12,9 @@ urlpatterns = [
     path('team-statistics/', team_statistics, name='team_statistics'),
     path('rugby-players/', rugby_players, name='rugby_players'),
     path('tournaments/', tournaments, name='tournaments'),
+    path('tournament-availability/', tournament_availability, name='tournament_availability'),
+    path('league-fixtures/', league_fixtures, name='league_fixtures'),
+    path('next-matchup/', next_matchup, name='next_matchup'),
     path('leagues/<int:league_id>/complete-draft/', complete_draft, name='complete_draft'),
     path('leagues/<int:league_id>/start-draft/', start_draft, name='start_draft'),
     path('leagues/<int:league_id>/draft-status/', get_draft_status, name='get_draft_status'),

--- a/backend/fantasy/views/__init__.py
+++ b/backend/fantasy/views/__init__.py
@@ -22,6 +22,7 @@ from .waiver_views import waiver_claims, process_waivers
 from .trade_views import trade_proposals, respond_to_trade
 from .tournament_views import tournaments
 from .chat_views import chat_messages, chat_participants, update_read_status
+from .matchweek_views import tournament_availability, league_fixtures, next_matchup
 
 __all__ = [
     'user_leagues',
@@ -41,5 +42,8 @@ __all__ = [
     'tournaments',
     'chat_messages',
     'chat_participants',
-    'update_read_status'
+    'update_read_status',
+    'tournament_availability',
+    'league_fixtures',
+    'next_matchup'
 ]

--- a/backend/fantasy/views/matchweek_views.py
+++ b/backend/fantasy/views/matchweek_views.py
@@ -1,0 +1,295 @@
+"""
+Matchweek management views for Fantasy Rugby API
+
+This module handles all matchweek-related operations including:
+- Tournament availability checking
+- Fixture generation and management
+- Matchup data retrieval
+"""
+
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from ..databricks_rest_client import DatabricksRestClient
+from .utils import get_cached_result, set_cached_result
+from datetime import datetime
+import random
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def tournament_availability(request):
+    """
+    Check which tournaments are available for new leagues (4+ weeks remaining)
+    
+    Returns:
+        List of available tournaments with weeks remaining
+    """
+    try:
+        client = DatabricksRestClient()
+        
+        cache_key = 'tournament_availability'
+        cached_result = get_cached_result(cache_key)
+        if cached_result:
+            return Response(cached_result)
+        
+        # Get current date
+        current_date = datetime.now().strftime('%Y-%m-%d')
+        
+        # Query tournaments with weeks remaining
+        sql = f"""
+        SELECT 
+            t.Tournamen_ID,
+            t.Tournament,
+            COUNT(tw.`Week Date`) as total_weeks,
+            MIN(tw.`Week Date`) as first_week,
+            MAX(tw.`Week Date`) as last_week
+        FROM default.tournaments t
+        LEFT JOIN default.tournament_weeks tw ON t.Tournamen_ID = tw.Tournament_ID
+        GROUP BY t.Tournamen_ID, t.Tournament
+        ORDER BY t.Tournament
+        """
+        
+        result = client.execute_sql(sql)
+        
+        if result and 'result' in result and 'data_array' in result['result']:
+            available_tournaments = []
+            
+            for row in result['result']['data_array']:
+                tournament_id, name, total_weeks, first_week, last_week = row
+                
+                # Calculate weeks remaining manually
+                try:
+                    current_date_obj = datetime.now().date()
+                    last_week_date = datetime.strptime(str(last_week), '%Y-%m-%d').date()
+                    weeks_remaining = max(0, (last_week_date - current_date_obj).days // 7)
+                except:
+                    weeks_remaining = 0
+                
+                # Only include tournaments with 4+ weeks remaining
+                if weeks_remaining >= 4:
+                    available_tournaments.append({
+                        'id': tournament_id,
+                        'name': name,
+                        'total_weeks': total_weeks,
+                        'weeks_remaining': weeks_remaining,
+                        'first_week': first_week,
+                        'last_week': last_week,
+                        'is_available': True
+                    })
+            
+            # Cache for 1 hour
+            set_cached_result(cache_key, available_tournaments, 3600)
+            
+            return Response(available_tournaments)
+        else:
+            return Response([])
+            
+    except Exception as e:
+        return Response({
+            'error': str(e)
+        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def league_fixtures(request):
+    """
+    Get all fixtures for a league
+    
+    Query parameters:
+    - league_id: League ID
+    """
+    try:
+        client = DatabricksRestClient()
+        
+        league_id = request.GET.get('league_id')
+        
+        if not league_id:
+            return Response({
+                'error': 'league_id is required'
+            }, status=status.HTTP_400_BAD_REQUEST)
+        
+        sql = f"""
+        SELECT 
+            id,
+            week_number,
+            week_date,
+            home_team_id,
+            away_team_id,
+            home_team_name,
+            away_team_name,
+            home_team_points,
+            away_team_points,
+            is_playoff
+        FROM default.league_fixtures 
+        WHERE league_id = {league_id}
+        ORDER BY week_number, id
+        """
+        
+        result = client.execute_sql(sql)
+        
+        if result and 'result' in result and 'data_array' in result['result']:
+            fixtures = []
+            for row in result['result']['data_array']:
+                fixtures.append({
+                    'id': row[0],
+                    'week_number': row[1],
+                    'week_date': row[2],
+                    'home_team_id': row[3],
+                    'away_team_id': row[4],
+                    'home_team_name': row[5],
+                    'away_team_name': row[6],
+                    'home_team_points': row[7] if row[7] is not None else 0.0,
+                    'away_team_points': row[8] if row[8] is not None else 0.0,
+                    'is_playoff': row[9]
+                })
+            
+            return Response(fixtures)
+        else:
+            return Response([])
+            
+    except Exception as e:
+        return Response({
+            'error': str(e)
+        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def next_matchup(request):
+    """
+    Get the next upcoming matchup for a user's team
+    
+    Query parameters:
+    - league_id: League ID
+    - user_id: User ID
+    """
+    try:
+        client = DatabricksRestClient()
+        
+        league_id = request.GET.get('league_id')
+        user_id = request.GET.get('user_id')
+        
+        if not league_id or not user_id:
+            return Response({
+                'error': 'league_id and user_id are required'
+            }, status=status.HTTP_400_BAD_REQUEST)
+        
+        # Get user's team
+        team_sql = f"""
+        SELECT id, team_name
+        FROM default.league_teams 
+        WHERE league_id = {league_id} AND team_owner_user_id = {user_id}
+        LIMIT 1
+        """
+        
+        team_result = client.execute_sql(team_sql)
+        
+        if not team_result or 'result' not in team_result or 'data_array' not in team_result['result']:
+            return Response({
+                'error': 'User team not found in this league'
+            }, status=status.HTTP_404_NOT_FOUND)
+        
+        team_id, team_name = team_result['result']['data_array'][0]
+        
+        # Get next upcoming fixture for this team
+        current_date = datetime.now().strftime('%Y-%m-%d')
+        
+        fixture_sql = f"""
+        SELECT 
+            id,
+            week_number,
+            week_date,
+            home_team_id,
+            away_team_id,
+            home_team_name,
+            away_team_name,
+            home_team_points,
+            away_team_points,
+            is_playoff
+        FROM default.league_fixtures 
+        WHERE league_id = {league_id} 
+        AND week_date >= '{current_date}'
+        AND (home_team_id = {team_id} OR away_team_id = {team_id})
+        ORDER BY week_date
+        LIMIT 1
+        """
+        
+        fixture_result = client.execute_sql(fixture_sql)
+        
+        if fixture_result and 'result' in fixture_result and 'data_array' in fixture_result['result']:
+            row = fixture_result['result']['data_array'][0]
+            
+            # Determine if user's team is home or away
+            is_home = row[3] == team_id
+            opponent_team_id = row[4] if is_home else row[3]
+            opponent_team_name = row[6] if is_home else row[5]
+            
+            matchup = {
+                'fixture_id': row[0],
+                'week_number': row[1],
+                'week_date': row[2],
+                'user_team': {
+                    'id': team_id,
+                    'name': team_name,
+                    'is_home': is_home,
+                    'points': row[7] if is_home else row[8]
+                },
+                'opponent_team': {
+                    'id': opponent_team_id,
+                    'name': opponent_team_name,
+                    'is_home': not is_home,
+                    'points': row[8] if is_home else row[7]
+                },
+                'is_playoff': row[9]
+            }
+            
+            return Response(matchup)
+        else:
+            return Response({
+                'message': 'No upcoming fixtures found'
+            })
+            
+    except Exception as e:
+        return Response({
+            'error': str(e)
+        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+def generate_round_robin_fixtures(teams, weeks_available):
+    """Generate round-robin fixtures for teams"""
+    if len(teams) < 2:
+        return []
+    
+    fixtures = []
+    num_teams = len(teams)
+    
+    # If odd number of teams, add a "bye" team
+    if num_teams % 2 == 1:
+        teams.append({"id": "BYE", "name": "BYE"})
+        num_teams += 1
+    
+    # Generate round-robin fixtures
+    for week in range(num_teams - 1):
+        week_fixtures = []
+        
+        # Rotate teams (except first team)
+        if week > 0:
+            teams[1:] = teams[2:] + [teams[1]]
+        
+        # Create matches for this week
+        for i in range(num_teams // 2):
+            home_team = teams[i]
+            away_team = teams[num_teams - 1 - i]
+            
+            if home_team["id"] != "BYE" and away_team["id"] != "BYE":
+                week_fixtures.append({
+                    'home_team_id': home_team["id"],
+                    'away_team_id': away_team["id"],
+                    'home_team_name': home_team["name"],
+                    'away_team_name': away_team["name"],
+                    'week': week + 1
+                })
+        
+        fixtures.extend(week_fixtures)
+    
+    return fixtures

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,5 +63,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8000"
+  "proxy": "http://localhost:8001"
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,17 +1,42 @@
-/* Fantasy Rugby - Orange, Black, White Theme */
+/* Fantasy Rugby - Databricks Inspired Design System */
 
 :root {
-  --primary-orange: #d35400;
-  --dark-orange: #b8460a;
-  --light-orange: #e67e22;
-  --black: #1A1A1A;
-  --dark-gray: #2D2D2D;
-  --light-gray: #F5F5F5;
+  /* Royal Blue Primary Colors */
+  --databricks-blue: #4169E1;
+  --databricks-dark-blue: #1E3A8A;
+  --databricks-light-blue: #E6F0FF;
+  --databricks-accent: #00A86B;
+  
+  /* Neutral Palette */
+  --neutral-900: #1A1A1A;
+  --neutral-800: #2D2D2D;
+  --neutral-700: #404040;
+  --neutral-600: #666666;
+  --neutral-500: #808080;
+  --neutral-400: #999999;
+  --neutral-300: #CCCCCC;
+  --neutral-200: #E0E0E0;
+  --neutral-100: #F5F5F5;
+  --neutral-50: #FAFAFA;
   --white: #FFFFFF;
-  --success: #28A745;
-  --error: #DC3545;
-  --warning: #FFC107;
-  --info: #17A2B8;
+  
+  /* Semantic Colors */
+  --success: #00A86B;
+  --success-light: #E6F7F0;
+  --error: #E74C3C;
+  --error-light: #FDF2F2;
+  --warning: #F39C12;
+  --warning-light: #FEF9E7;
+  --info: #3498DB;
+  --info-light: #EBF5FB;
+  
+  /* Legacy support */
+  --primary-orange: var(--databricks-blue);
+  --dark-orange: var(--databricks-dark-blue);
+  --light-orange: var(--databricks-light-blue);
+  --black: var(--neutral-900);
+  --dark-gray: var(--neutral-800);
+  --light-gray: var(--neutral-100);
 }
 
 * {
@@ -21,10 +46,13 @@
 }
 
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: var(--white);
-  color: var(--black);
+  font-family: 'Inter', 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+  background-color: var(--neutral-50);
+  color: var(--neutral-900);
   line-height: 1.6;
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
 }
 
 .App {
@@ -35,154 +63,234 @@ body {
 
 .main-content {
   flex: 1;
-  padding: 2rem;
-  max-width: 1200px;
+  padding: 24px;
+  max-width: 1400px;
   margin: 0 auto;
   width: 100%;
+  background-color: var(--white);
+  min-height: calc(100vh - 64px);
 }
 
-/* Typography */
+/* Typography - Databricks Style */
 h1, h2, h3, h4, h5, h6 {
-  color: var(--black);
-  margin-bottom: 1rem;
+  color: var(--neutral-900);
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  font-family: 'Poppins', 'Inter', sans-serif;
+  letter-spacing: -0.02em;
 }
 
 h1 {
-  font-size: 2.5rem;
+  font-size: 32px;
   font-weight: 700;
+  color: var(--databricks-blue);
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: 24px;
   font-weight: 600;
 }
 
 h3 {
-  font-size: 1.5rem;
+  font-size: 20px;
   font-weight: 600;
 }
 
-/* Buttons */
-.btn {
-  padding: 0.75rem 1.5rem;
-  border: none;
-  border-radius: 8px;
-  font-size: 1rem;
+h4 {
+  font-size: 16px;
   font-weight: 600;
+}
+
+h5 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+h6 {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Buttons - Databricks Style */
+.btn {
+  padding: 8px 16px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: 'Inter', 'Poppins', sans-serif;
+  letter-spacing: -0.01em;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
   text-decoration: none;
-  display: inline-block;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 32px;
+  white-space: nowrap;
 }
 
 .btn-primary {
-  background-color: var(--primary-orange);
+  background-color: var(--databricks-blue);
   color: var(--white);
+  border-color: var(--databricks-blue);
 }
 
 .btn-primary:hover {
-  background-color: var(--dark-orange);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(255, 107, 53, 0.3);
+  background-color: var(--databricks-dark-blue);
+  border-color: var(--databricks-dark-blue);
+  box-shadow: 0 2px 4px rgba(0, 102, 204, 0.2);
 }
 
 .btn-secondary {
-  background-color: var(--black);
-  color: var(--white);
+  background-color: var(--neutral-100);
+  color: var(--neutral-700);
+  border-color: var(--neutral-200);
 }
 
 .btn-secondary:hover {
-  background-color: var(--dark-gray);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(26, 26, 26, 0.3);
+  background-color: var(--neutral-200);
+  border-color: var(--neutral-300);
 }
 
 .btn-outline {
   background-color: transparent;
-  color: var(--primary-orange);
-  border: 2px solid var(--primary-orange);
+  color: var(--databricks-blue);
+  border-color: var(--databricks-blue);
 }
 
 .btn-outline:hover {
-  background-color: var(--primary-orange);
-  color: var(--white);
+  background-color: var(--databricks-light-blue);
+  border-color: var(--databricks-blue);
 }
 
 .btn-large {
-  padding: 1rem 2rem;
-  font-size: 1.1rem;
+  padding: 12px 24px;
+  font-size: 16px;
+  min-height: 40px;
 }
 
 .btn-small {
-  padding: 0.5rem 1rem;
-  font-size: 0.9rem;
+  padding: 4px 12px;
+  font-size: 12px;
+  min-height: 24px;
 }
 
-/* Forms */
+.btn-icon {
+  padding: 8px;
+  min-width: 32px;
+  min-height: 32px;
+}
+
+/* Forms - Databricks Style */
 .form-group {
-  margin-bottom: 1.5rem;
+  margin-bottom: 16px;
 }
 
 .form-label {
   display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--black);
+  margin-bottom: 6px;
+  font-weight: 500;
+  color: var(--neutral-700);
+  font-size: 14px;
 }
 
 .form-input {
   width: 100%;
-  padding: 0.75rem;
-  border: 2px solid #E0E0E0;
+  padding: 8px 12px;
+  border: 1px solid var(--neutral-200);
   border-radius: 8px;
-  font-size: 1rem;
-  transition: border-color 0.3s ease;
+  font-size: 14px;
+  transition: all 0.2s ease;
+  background-color: var(--white);
+  color: var(--neutral-900);
+  font-family: 'Inter', 'Poppins', sans-serif;
+  letter-spacing: -0.01em;
 }
 
 .form-input:focus {
   outline: none;
-  border-color: var(--primary-orange);
-  box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
+  border-color: var(--databricks-blue);
+  box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
+}
+
+.form-input:disabled {
+  background-color: var(--neutral-50);
+  color: var(--neutral-500);
+  cursor: not-allowed;
 }
 
 .form-input.error {
   border-color: var(--error);
 }
 
+.form-input.error:focus {
+  box-shadow: 0 0 0 2px rgba(231, 76, 60, 0.1);
+}
+
 .form-error {
   color: var(--error);
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
+  font-size: 12px;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .form-success {
   color: var(--success);
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
+  font-size: 12px;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
-/* Cards */
+.form-help {
+  color: var(--neutral-600);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+/* Cards - Databricks Style */
 .card {
   background: var(--white);
-  border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  padding: 2rem;
-  margin-bottom: 2rem;
-  border: 1px solid #E0E0E0;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  margin-bottom: 16px;
+  border: 1px solid var(--neutral-200);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .card-header {
-  border-bottom: 2px solid var(--light-gray);
-  padding-bottom: 1rem;
-  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--neutral-200);
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .card-title {
-  color: var(--black);
-  font-size: 1.5rem;
+  color: var(--neutral-900);
+  font-size: 18px;
   font-weight: 600;
   margin: 0;
+}
+
+.card-subtitle {
+  color: var(--neutral-600);
+  font-size: 14px;
+  margin-top: 4px;
 }
 
 /* Alerts */
@@ -271,10 +379,105 @@ input[type="password"] {
   outline-offset: 2px;
 }
 
+/* Databricks-style Utility Classes */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.badge-primary {
+  background-color: var(--databricks-light-blue);
+  color: var(--databricks-blue);
+}
+
+.badge-success {
+  background-color: var(--success-light);
+  color: var(--success);
+}
+
+.badge-warning {
+  background-color: var(--warning-light);
+  color: var(--warning);
+}
+
+.badge-error {
+  background-color: var(--error-light);
+  color: var(--error);
+}
+
+.badge-neutral {
+  background-color: var(--neutral-100);
+  color: var(--neutral-700);
+}
+
+/* Status Indicators */
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.status-indicator::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-indicator.success::before {
+  background-color: var(--success);
+}
+
+.status-indicator.warning::before {
+  background-color: var(--warning);
+}
+
+.status-indicator.error::before {
+  background-color: var(--error);
+}
+
+.status-indicator.info::before {
+  background-color: var(--info);
+}
+
+/* Data Table Styles */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.data-table th {
+  background-color: var(--neutral-50);
+  color: var(--neutral-700);
+  font-weight: 600;
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--neutral-200);
+}
+
+.data-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--neutral-100);
+  color: var(--neutral-900);
+}
+
+.data-table tr:hover {
+  background-color: var(--neutral-50);
+}
+
 /* High contrast mode support */
 @media (prefers-contrast: high) {
   :root {
-    --primary-orange: #FF4500;
-    --black: #000000;
+    --databricks-blue: #0066CC;
+    --neutral-900: #000000;
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,7 +30,8 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { AuthProvider } from './contexts/AuthContext';
 import { ThemeProvider } from './contexts/ThemeContext';
 import ProtectedRoute from './components/ProtectedRoute';
-import Navbar from './components/Navbar';
+import Header from './components/Header';
+import Footer from './components/Footer';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import LeagueSelection from './pages/LeagueSelection';
@@ -53,7 +54,7 @@ function App() {
       <AuthProvider>
         <Router>
           <div className="App">
-            <Navbar />
+            <Header />
             <main className="main-content">
               <Routes>
                 <Route path="/login" element={<Login />} />
@@ -93,6 +94,7 @@ function App() {
                 <Route path="/" element={<Navigate to="/league-selection" replace />} />
               </Routes>
             </main>
+            <Footer />
           </div>
         </Router>
       </AuthProvider>

--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -1,0 +1,397 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+const Chat = ({ leagueId, isActive, onUnreadCountChange }) => {
+  const [messages, setMessages] = useState([]);
+  const [newMessage, setNewMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [participants, setParticipants] = useState([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [lastMessageTimestamp, setLastMessageTimestamp] = useState(null);
+  const [lastReadTimestamp, setLastReadTimestamp] = useState(null);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const messagesEndRef = useRef(null);
+  const { user } = useAuth();
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  // Calculate unread messages count
+  const calculateUnreadCount = (messages, lastReadTimestamp) => {
+    if (!lastReadTimestamp || !messages.length) return 0;
+    
+    const unreadMessages = messages.filter(msg => {
+      // Don't count messages from the current user
+      if (msg.user_id === user?.id) return false;
+      // Count messages newer than last read timestamp
+      return new Date(msg.timestamp) > new Date(lastReadTimestamp);
+    });
+    
+    return unreadMessages.length;
+  };
+
+  // Check for new messages only
+  const checkForNewMessages = async () => {
+    if (!leagueId || !isActive || !lastMessageTimestamp) return;
+    
+    try {
+      const response = await fetch(`http://localhost:8001/api/leagues/${leagueId}/chat/messages/?limit=50&offset=0`, {
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        }
+      });
+      
+      if (response.ok) {
+        const data = await response.json();
+        if (data.messages && data.messages.length > 0) {
+          // Find new messages since last timestamp
+          const newMessages = data.messages.filter(msg => 
+            new Date(msg.timestamp) > new Date(lastMessageTimestamp)
+          );
+          
+          if (newMessages.length > 0) {
+            setMessages(prev => [...prev, ...newMessages]);
+            setLastMessageTimestamp(newMessages[newMessages.length - 1].timestamp);
+            scrollToBottom();
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error checking for new messages:', error);
+    }
+  };
+
+  // Load messages
+  const loadMessages = async (reset = false) => {
+    if (!leagueId || !isActive) return;
+    
+    setLoading(true);
+    try {
+      const currentOffset = reset ? 0 : offset;
+      const response = await fetch(`http://localhost:8001/api/leagues/${leagueId}/chat/messages/?limit=50&offset=${currentOffset}`, {
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        }
+      });
+      
+      if (response.ok) {
+        const data = await response.json();
+        if (reset) {
+          setMessages(data.messages || []);
+          setOffset(50);
+          // Set the timestamp of the newest message
+          if (data.messages && data.messages.length > 0) {
+            setLastMessageTimestamp(data.messages[0].timestamp);
+            // Set last read timestamp to current time when actively viewing chat
+            if (isActive) {
+              setLastReadTimestamp(new Date().toISOString());
+            }
+          }
+        } else {
+          setMessages(prev => [...prev, ...(data.messages || [])]);
+          setOffset(prev => prev + 50);
+        }
+        setHasMore(data.has_more || false);
+      }
+    } catch (error) {
+      console.error('Error loading messages:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Load participants
+  const loadParticipants = async () => {
+    if (!leagueId || !isActive) return;
+    
+    try {
+      const response = await fetch(`http://localhost:8001/api/leagues/${leagueId}/chat/participants/`, {
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        }
+      });
+      
+      if (response.ok) {
+        const data = await response.json();
+        setParticipants(data.participants || []);
+        
+        // Set last read timestamp from participant data
+        const currentUserParticipant = data.participants?.find(p => p.user_id === user?.id);
+        if (currentUserParticipant?.last_read_at) {
+          setLastReadTimestamp(currentUserParticipant.last_read_at);
+        }
+      }
+    } catch (error) {
+      console.error('Error loading participants:', error);
+    }
+  };
+
+  // Join chat
+  const joinChat = async () => {
+    if (!user?.id || !leagueId) return;
+    
+    try {
+      const response = await fetch(`http://localhost:8001/api/leagues/${leagueId}/chat/participants/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        },
+        body: JSON.stringify({ user_id: user.id })
+      });
+      
+      if (response.ok) {
+        console.log('Joined chat successfully');
+      }
+    } catch (error) {
+      console.error('Error joining chat:', error);
+    }
+  };
+
+  // Send message
+  const sendMessage = async (e) => {
+    e.preventDefault();
+    if (!newMessage.trim() || !user?.id || sending) return;
+    
+    setSending(true);
+    try {
+      const response = await fetch(`http://localhost:8001/api/leagues/${leagueId}/chat/messages/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        },
+        body: JSON.stringify({
+          user_id: user.id,
+          message: newMessage.trim(),
+          message_type: 'text'
+        })
+      });
+      
+      if (response.ok) {
+        const newMsg = await response.json();
+        setMessages(prev => [...prev, newMsg]);
+        setLastMessageTimestamp(newMsg.timestamp);
+        setNewMessage('');
+        scrollToBottom();
+      } else {
+        console.error('Failed to send message');
+      }
+    } catch (error) {
+      console.error('Error sending message:', error);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  // Update read status
+  const updateReadStatus = async () => {
+    if (!user?.id || !leagueId) return;
+    
+    try {
+      await fetch(`http://localhost:8001/api/leagues/${leagueId}/chat/users/${user.id}/read-status/`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        }
+      });
+    } catch (error) {
+      console.error('Error updating read status:', error);
+    }
+  };
+
+  // Load data on mount and when leagueId changes
+  useEffect(() => {
+    if (leagueId && isActive) {
+      joinChat();
+      loadMessages(true);
+      loadParticipants();
+    }
+  }, [leagueId, isActive]);
+
+  // Poll for new messages every 3 seconds
+  useEffect(() => {
+    if (!leagueId || !isActive) return;
+    
+    const interval = setInterval(() => {
+      checkForNewMessages();
+    }, 3000);
+    
+    return () => clearInterval(interval);
+  }, [leagueId, isActive, lastMessageTimestamp]);
+
+  // Update read status when messages change
+  useEffect(() => {
+    if (messages.length > 0) {
+      updateReadStatus();
+    }
+  }, [messages]);
+
+  // Update unread count and notify parent
+  useEffect(() => {
+    const count = calculateUnreadCount(messages, lastReadTimestamp);
+    setUnreadCount(count);
+    if (onUnreadCountChange) {
+      onUnreadCountChange(count);
+    }
+  }, [messages, lastReadTimestamp, user?.id]);
+
+  // Mark messages as read when chat becomes active
+  useEffect(() => {
+    if (isActive) {
+      const currentTime = new Date().toISOString();
+      setLastReadTimestamp(currentTime);
+      // Update read status on server
+      updateReadStatus();
+    }
+  }, [isActive]);
+
+  // Scroll to bottom when new messages arrive
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  // Format timestamp
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return '';
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+    
+    if (diffMins < 1) return 'Just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    
+    return date.toLocaleDateString();
+  };
+
+  if (!isActive) return null;
+
+  return (
+    <div className="card" style={{ height: '500px', display: 'flex', flexDirection: 'column' }}>
+      {/* Chat Header */}
+      <div style={{
+        padding: '16px 20px',
+        borderBottom: '1px solid var(--border-light)',
+        backgroundColor: 'var(--neutral-50)',
+        borderRadius: '8px 8px 0 0'
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h3 style={{ margin: 0, color: 'var(--databricks-blue)', fontSize: '18px' }}>
+            💬 League Chat
+          </h3>
+          <div style={{ fontSize: '14px', color: 'var(--neutral-600)' }}>
+            {participants.length} participant{participants.length !== 1 ? 's' : ''}
+          </div>
+        </div>
+      </div>
+
+      {/* Messages Container */}
+      <div style={{
+        flex: 1,
+        overflowY: 'auto',
+        padding: '16px 20px',
+        display: 'flex',
+        flexDirection: 'column' // Normal column direction
+      }}>
+        {loading && messages.length === 0 && (
+          <div style={{ textAlign: 'center', color: 'var(--neutral-600)', padding: '20px' }}>
+            Loading messages...
+          </div>
+        )}
+        
+        {messages.length === 0 && !loading && (
+          <div style={{ textAlign: 'center', color: 'var(--neutral-600)', padding: '20px' }}>
+            No messages yet. Start the conversation!
+          </div>
+        )}
+        
+        {messages.slice().reverse().map((message, index) => (
+          <div
+            key={`${message.id}-${index}`}
+            style={{
+              marginBottom: '12px',
+              padding: '8px 12px',
+              borderRadius: '8px',
+              backgroundColor: message.user_id === user?.id ? 'var(--databricks-light-blue)' : 'var(--neutral-100)',
+              alignSelf: message.user_id === user?.id ? 'flex-end' : 'flex-start',
+              maxWidth: '70%',
+              wordWrap: 'break-word'
+            }}
+          >
+            <div style={{
+              fontSize: '12px',
+              color: 'var(--neutral-600)',
+              marginBottom: '4px',
+              fontWeight: '600'
+            }}>
+              {message.username} • {formatTimestamp(message.timestamp)}
+            </div>
+            <div style={{
+              fontSize: '14px',
+              color: 'var(--neutral-800)',
+              lineHeight: '1.4'
+            }}>
+              {message.message}
+            </div>
+          </div>
+        ))}
+        
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Message Input */}
+      <div style={{
+        padding: '16px 20px',
+        borderTop: '1px solid var(--border-light)',
+        backgroundColor: 'var(--neutral-50)',
+        borderRadius: '0 0 8px 8px'
+      }}>
+        <form onSubmit={sendMessage} style={{ display: 'flex', gap: '12px' }}>
+          <input
+            type="text"
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            placeholder="Type your message..."
+            style={{
+              flex: 1,
+              padding: '10px 12px',
+              border: '1px solid var(--border-light)',
+              borderRadius: '6px',
+              fontSize: '14px',
+              outline: 'none',
+              backgroundColor: 'white'
+            }}
+            disabled={sending}
+          />
+          <button
+            type="submit"
+            disabled={!newMessage.trim() || sending}
+            style={{
+              padding: '10px 20px',
+              backgroundColor: sending ? 'var(--neutral-300)' : 'var(--databricks-blue)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              fontSize: '14px',
+              fontWeight: '600',
+              cursor: sending ? 'not-allowed' : 'pointer',
+              opacity: sending ? 0.6 : 1
+            }}
+          >
+            {sending ? 'Sending...' : 'Send'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Chat;

--- a/frontend/src/components/Fixtures.js
+++ b/frontend/src/components/Fixtures.js
@@ -1,0 +1,200 @@
+import React, { useState, useEffect } from 'react';
+import { tournamentsAPI } from '../services/api';
+
+const Fixtures = ({ leagueId, user, isActive }) => {
+  const [fixtures, setFixtures] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Load fixtures when component becomes active
+  useEffect(() => {
+    if (isActive && leagueId) {
+      loadFixtures();
+    }
+  }, [isActive, leagueId]);
+
+  const loadFixtures = async () => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const fixturesData = await tournamentsAPI.getLeagueFixtures(leagueId);
+      setFixtures(fixturesData || []);
+    } catch (error) {
+      console.error('Error loading fixtures:', error);
+      setError('Failed to load fixtures');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+
+  const groupFixturesByWeek = (fixtures) => {
+    const grouped = {};
+    fixtures.forEach(fixture => {
+      const week = fixture.week_number;
+      if (!grouped[week]) {
+        grouped[week] = [];
+      }
+      grouped[week].push(fixture);
+    });
+    return grouped;
+  };
+
+  const formatDate = (dateString) => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-GB', {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short'
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: '2rem' }}>
+      <div className="card-header">
+        <div>
+          <h3 className="card-title">League Fixtures</h3>
+          <p style={{ margin: '0.5rem 0 0 0', color: 'var(--dark-gray)', fontSize: '0.95rem' }}>
+            View all scheduled matches for this league
+          </p>
+        </div>
+      </div>
+
+      <div style={{ padding: '1rem' }}>
+        {loading && (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <p>Loading fixtures...</p>
+          </div>
+        )}
+
+        {error && (
+          <div style={{
+            padding: '1rem',
+            backgroundColor: '#FFEBEE',
+            border: '1px solid #F44336',
+            borderRadius: '6px',
+            color: '#C62828',
+            marginBottom: '1rem'
+          }}>
+            {error}
+          </div>
+        )}
+
+        {!loading && fixtures.length === 0 && (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <p style={{ color: 'var(--dark-gray)', marginBottom: '1rem' }}>
+              No fixtures available for this league yet.
+            </p>
+            <p style={{ color: 'var(--dark-gray)', fontSize: '0.9rem' }}>
+              Fixtures will be automatically generated when teams join the league.
+            </p>
+          </div>
+        )}
+
+        {!loading && fixtures.length > 0 && (
+          <div>
+            {Object.entries(groupFixturesByWeek(fixtures))
+              .sort(([a], [b]) => parseInt(a) - parseInt(b))
+              .map(([week, weekFixtures]) => (
+                <div key={week} style={{ marginBottom: '2rem' }}>
+                  <h4 style={{
+                    color: 'var(--primary-orange)',
+                    marginBottom: '1rem',
+                    fontSize: '1.2rem',
+                    borderBottom: '2px solid var(--light-gray)',
+                    paddingBottom: '0.5rem'
+                  }}>
+                    Week {week}
+                    {weekFixtures[0]?.is_playoff && (
+                      <span style={{
+                        marginLeft: '0.5rem',
+                        padding: '0.25rem 0.5rem',
+                        backgroundColor: '#FF9800',
+                        color: 'white',
+                        borderRadius: '4px',
+                        fontSize: '0.8rem',
+                        fontWeight: 'bold'
+                      }}>
+                        PLAYOFF
+                      </span>
+                    )}
+                  </h4>
+                  
+                  <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                    gap: '1rem'
+                  }}>
+                    {weekFixtures.map((fixture) => (
+                      <div
+                        key={fixture.id}
+                        style={{
+                          padding: '1rem',
+                          border: '1px solid var(--light-gray)',
+                          borderRadius: '8px',
+                          backgroundColor: 'white'
+                        }}
+                      >
+                        <div style={{
+                          textAlign: 'center',
+                          marginBottom: '0.5rem',
+                          fontSize: '0.9rem',
+                          color: 'var(--dark-gray)'
+                        }}>
+                          {formatDate(fixture.week_date)}
+                        </div>
+                        
+                        <div style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          marginBottom: '0.5rem'
+                        }}>
+                          <div style={{ flex: 1, textAlign: 'right', marginRight: '1rem' }}>
+                            <div style={{ fontWeight: 'bold', fontSize: '1rem' }}>
+                              {fixture.home_team_name}
+                            </div>
+                            <div style={{ fontSize: '0.9rem', color: 'var(--dark-gray)' }}>
+                              {fixture.home_team_points.toFixed(1)} pts
+                            </div>
+                          </div>
+                          
+                          <div style={{
+                            fontSize: '1.5rem',
+                            fontWeight: 'bold',
+                            color: 'var(--primary-orange)'
+                          }}>
+                            VS
+                          </div>
+                          
+                          <div style={{ flex: 1, textAlign: 'left', marginLeft: '1rem' }}>
+                            <div style={{ fontWeight: 'bold', fontSize: '1rem' }}>
+                              {fixture.away_team_name}
+                            </div>
+                            <div style={{ fontSize: '0.9rem', color: 'var(--dark-gray)' }}>
+                              {fixture.away_team_points.toFixed(1)} pts
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Fixtures;

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const Footer = () => {
+  return (
+    <footer style={{
+      backgroundColor: 'var(--neutral-50)',
+      borderTop: '1px solid var(--neutral-200)',
+      padding: '16px 24px',
+      marginTop: 'auto',
+      textAlign: 'center',
+      fontSize: '12px',
+      color: 'var(--neutral-600)'
+    }}>
+      <p style={{ margin: 0 }}>
+        Rugby ball icons created by{' '}
+        <a 
+          href="https://www.flaticon.com/free-icons/rugby-ball" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          style={{ 
+            color: 'var(--databricks-blue)', 
+            textDecoration: 'none' 
+          }}
+        >
+          juicy_fish - Flaticon
+        </a>
+      </p>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,0 +1,144 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+const Header = () => {
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <header style={{
+      backgroundColor: 'var(--white)',
+      borderBottom: '1px solid var(--neutral-200)',
+      padding: '0 24px',
+      height: '64px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      position: 'sticky',
+      top: 0,
+      zIndex: 1000,
+      boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
+    }}>
+      {/* Logo and Brand */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '16px'
+      }}>
+        <div 
+          onClick={() => navigate('/')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            cursor: 'pointer'
+          }}
+        >
+          <div style={{
+            width: '32px',
+            height: '32px',
+            backgroundColor: 'var(--databricks-blue)',
+            borderRadius: '6px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '4px'
+          }}>
+            <img 
+              src="/rugby-ball.png" 
+              alt="Rugby Ball" 
+              style={{
+                width: '24px',
+                height: '24px',
+                objectFit: 'contain'
+              }}
+            />
+          </div>
+          <div>
+            <h1 style={{
+              fontSize: '20px',
+              fontWeight: '700',
+              color: 'var(--databricks-blue)',
+              margin: 0,
+              lineHeight: 1
+            }}>
+              Fantasy Rugby
+            </h1>
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px'
+      }}>
+        {user ? (
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px'
+          }}>
+            <div style={{
+              width: '32px',
+              height: '32px',
+              backgroundColor: 'var(--databricks-blue)',
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'white',
+              fontSize: '14px',
+              fontWeight: 'bold',
+              cursor: 'pointer',
+              transition: 'all 0.2s ease'
+            }}
+            onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--databricks-dark-blue)'}
+            onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'var(--databricks-blue)'}
+            >
+              {user.username?.charAt(0)?.toUpperCase() || 'U'}
+            </div>
+            
+            <button
+              onClick={handleLogout}
+              className="btn btn-secondary btn-small"
+              style={{ fontSize: '14px' }}
+            >
+              Sign Out
+            </button>
+          </div>
+        ) : (
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px'
+          }}>
+            <button
+              onClick={() => navigate('/login')}
+              className="btn btn-outline btn-small"
+              style={{ fontSize: '14px' }}
+            >
+              Sign In
+            </button>
+            <button
+              onClick={() => navigate('/register')}
+              className="btn btn-primary btn-small"
+              style={{ fontSize: '14px' }}
+            >
+              Sign Up
+            </button>
+          </div>
+        )}
+      </nav>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/LeagueTable.js
+++ b/frontend/src/components/LeagueTable.js
@@ -11,13 +11,17 @@ const LeagueTable = ({
 }) => {
   if (loading) {
     return (
-      <div className="card" style={{ marginBottom: '2rem' }}>
+      <div className="card" style={{ marginBottom: '24px' }}>
         <div className="card-header">
           <h3 className="card-title">Teams in League</h3>
         </div>
-        <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <div style={{ 
+          padding: '48px 24px', 
+          textAlign: 'center',
+          color: 'var(--neutral-600)'
+        }}>
           <div className="spinner"></div>
-          <p>Loading teams...</p>
+          <p style={{ marginTop: '16px', fontSize: '14px' }}>Loading teams...</p>
         </div>
       </div>
     );
@@ -25,11 +29,11 @@ const LeagueTable = ({
 
   if (error) {
     return (
-      <div className="card" style={{ marginBottom: '2rem' }}>
+      <div className="card" style={{ marginBottom: '24px' }}>
         <div className="card-header">
           <h3 className="card-title">Teams in League</h3>
         </div>
-        <div className="alert alert-error" style={{ marginBottom: '1rem' }}>
+        <div className="alert alert-error" style={{ marginBottom: '16px' }}>
           {error}
         </div>
       </div>
@@ -37,109 +41,122 @@ const LeagueTable = ({
   }
 
   return (
-    <div className="card" style={{ marginBottom: '2rem' }}>
-      <div className="card-header">
-        <h3 className="card-title">Teams in League ({teams.length}/{leagueData?.max_teams})</h3>
-      </div>
+    <div className="card" style={{ marginBottom: '24px' }}>
       
       {error && (
-        <div className="alert alert-error" style={{ marginBottom: '1rem' }}>
+        <div className="alert alert-error" style={{ marginBottom: '16px' }}>
           {error}
         </div>
       )}
       
       {teams.length === 0 ? (
-        <div style={{ padding: '2rem', textAlign: 'center' }}>
-          <p>No teams have joined this league yet.</p>
+        <div style={{ 
+          padding: '48px 24px', 
+          textAlign: 'center',
+          color: 'var(--neutral-600)'
+        }}>
+          <p style={{ fontSize: '16px', marginBottom: '24px' }}>No teams have joined this league yet.</p>
           {isAdmin && !draftComplete && (
             <button 
               onClick={onStartDraft}
               className="btn btn-primary"
-              style={{ 
-                backgroundColor: 'var(--primary-orange)', 
-                border: 'none',
-                padding: '0.5rem 1rem',
-                borderRadius: '4px',
-                color: 'white',
-                cursor: 'pointer'
-              }}
+              style={{ fontSize: '14px' }}
             >
               Start Draft
             </button>
           )}
         </div>
       ) : (
-        <div style={{ overflowX: 'auto' }}>
-          <table style={{ 
-            width: '100%', 
-            borderCollapse: 'collapse',
-            backgroundColor: 'white',
-            borderRadius: '8px',
-            overflow: 'hidden'
-          }}>
+        <div style={{ 
+          overflowX: 'auto', 
+          borderRadius: '8px', 
+          border: '1px solid var(--neutral-200)',
+          maxWidth: '800px',
+          margin: '0 auto'
+        }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ backgroundColor: 'var(--primary-orange)', color: 'white' }}>
+              <tr>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'left', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
-                }}>
-                  #
-                </th>
-                <th style={{ 
-                  padding: '1rem', 
-                  textAlign: 'left', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)'
                 }}>
                   Team Name
                 </th>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'center', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)',
+                  width: '80px'
                 }}>
                   W
                 </th>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'center', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)',
+                  width: '80px'
                 }}>
                   L
                 </th>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'center', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)',
+                  width: '80px'
                 }}>
                   D
                 </th>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'center', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)',
+                  width: '80px'
                 }}>
                   PF
                 </th>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'center', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)',
+                  width: '80px'
                 }}>
                   PA
                 </th>
                 <th style={{ 
-                  padding: '1rem', 
+                  padding: '12px 16px', 
                   textAlign: 'center', 
-                  fontWeight: 'bold',
-                  fontSize: '1rem'
+                  fontWeight: '600',
+                  fontSize: '14px',
+                  color: 'var(--neutral-700)',
+                  backgroundColor: 'var(--neutral-50)',
+                  borderBottom: '1px solid var(--neutral-200)',
+                  width: '80px'
                 }}>
                   Pts
                 </th>
@@ -150,75 +167,73 @@ const LeagueTable = ({
                 <tr 
                   key={team.id || index}
                   style={{ 
-                    borderBottom: '1px solid #e0e0e0',
-                    backgroundColor: 'white',
-                    transition: 'background-color 0.2s'
+                    borderBottom: '1px solid var(--neutral-100)',
+                    backgroundColor: 'var(--white)',
+                    transition: 'background-color 0.2s ease'
                   }}
-                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#f8f9fa'}
-                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'white'}
+                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--neutral-50)'}
+                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'var(--white)'}
                 >
                   <td style={{ 
-                    padding: '1rem', 
-                    fontWeight: 'bold',
-                    color: 'var(--primary-orange)',
-                    fontSize: '1.1rem'
-                  }}>
-                    {index + 1}
-                  </td>
-                  <td style={{ 
-                    padding: '1rem',
-                    fontWeight: 'bold',
-                    color: 'var(--black)',
-                    fontSize: '1rem'
+                    padding: '12px 16px',
+                    fontWeight: '600',
+                    color: 'var(--neutral-900)',
+                    fontSize: '14px'
                   }}>
                     {team.team_name}
                   </td>
                   <td style={{ 
-                    padding: '1rem',
-                    color: 'var(--dark-gray)',
+                    padding: '12px 16px',
+                    color: 'var(--neutral-700)',
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: '500',
+                    fontSize: '14px'
                   }}>
                     {team.wins || 0}
                   </td>
                   <td style={{ 
-                    padding: '1rem',
-                    color: 'var(--dark-gray)',
+                    padding: '12px 16px',
+                    color: 'var(--neutral-700)',
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: '500',
+                    fontSize: '14px'
                   }}>
                     {team.losses || 0}
                   </td>
                   <td style={{ 
-                    padding: '1rem',
-                    color: 'var(--dark-gray)',
+                    padding: '12px 16px',
+                    color: 'var(--neutral-700)',
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: '500',
+                    fontSize: '14px'
                   }}>
                     {team.draws || 0}
                   </td>
                   <td style={{ 
-                    padding: '1rem',
-                    color: 'var(--dark-gray)',
+                    padding: '12px 16px',
+                    color: 'var(--neutral-700)',
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: '500',
+                    fontSize: '14px'
                   }}>
                     {team.points_for || 0}
                   </td>
                   <td style={{ 
-                    padding: '1rem',
-                    color: 'var(--dark-gray)',
+                    padding: '12px 16px',
+                    color: 'var(--neutral-700)',
                     textAlign: 'center',
-                    fontWeight: 'bold'
+                    fontWeight: '500',
+                    fontSize: '14px'
                   }}>
                     {team.points_against || 0}
                   </td>
                   <td style={{ 
-                    padding: '1rem',
-                    color: 'var(--primary-orange)',
+                    padding: '12px 16px',
+                    color: 'var(--databricks-blue)',
                     textAlign: 'center',
-                    fontWeight: 'bold',
-                    fontSize: '1.1rem'
+                    fontWeight: '600',
+                    fontSize: '14px',
+                    backgroundColor: index < 3 ? 'var(--databricks-light-blue)' : 'transparent'
                   }}>
                     {team.league_points || 0}
                   </td>

--- a/frontend/src/components/Matchup.js
+++ b/frontend/src/components/Matchup.js
@@ -1,0 +1,269 @@
+import React, { useState, useEffect } from 'react';
+import { tournamentsAPI } from '../services/api';
+
+const Matchup = ({ leagueId, user, isActive }) => {
+  const [matchup, setMatchup] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Load matchup when component becomes active
+  useEffect(() => {
+    if (isActive && leagueId && user?.id) {
+      loadNextMatchup();
+    }
+  }, [isActive, leagueId, user?.id]);
+
+  const loadNextMatchup = async () => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const matchupData = await tournamentsAPI.getNextMatchup(leagueId, user.id);
+      
+      // Validate the matchup data structure
+      if (matchupData && typeof matchupData === 'object') {
+        // Check if it's an error message
+        if (matchupData.message && !matchupData.user_team) {
+          // This is likely a "no upcoming fixtures" message
+          setMatchup(null);
+        } else if (matchupData.user_team && matchupData.opponent_team) {
+          // Valid matchup data
+          setMatchup(matchupData);
+        } else {
+          // Invalid data structure
+          console.warn('Invalid matchup data structure:', matchupData);
+          setMatchup(null);
+        }
+      } else {
+        setMatchup(null);
+      }
+    } catch (error) {
+      console.error('Error loading matchup:', error);
+      setError('Failed to load matchup data');
+      setMatchup(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (dateString) => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-GB', {
+        weekday: 'long',
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric'
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: '2rem' }}>
+      <div className="card-header">
+        <h3 className="card-title">Next Matchup</h3>
+        <p style={{ margin: '0.5rem 0 0 0', color: 'var(--dark-gray)', fontSize: '0.95rem' }}>
+          Your upcoming fantasy rugby match
+        </p>
+      </div>
+
+      <div style={{ padding: '1rem' }}>
+        {loading && (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <p>Loading matchup...</p>
+          </div>
+        )}
+
+        {error && (
+          <div style={{
+            padding: '1rem',
+            backgroundColor: '#FFEBEE',
+            border: '1px solid #F44336',
+            borderRadius: '6px',
+            color: '#C62828',
+            marginBottom: '1rem'
+          }}>
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && !matchup && (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <p style={{ color: 'var(--dark-gray)' }}>
+              No upcoming fixtures found.
+            </p>
+            <p style={{ color: 'var(--dark-gray)', fontSize: '0.9rem' }}>
+              Fixtures may not have been generated yet, or the season may have ended.
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && matchup && matchup.user_team && matchup.opponent_team && (
+          <div>
+            {/* Match Header */}
+            <div style={{
+              textAlign: 'center',
+              marginBottom: '2rem',
+              padding: '1rem',
+              backgroundColor: 'var(--lightest-gray)',
+              borderRadius: '8px'
+            }}>
+              <h4 style={{
+                margin: '0 0 0.5rem 0',
+                color: 'var(--primary-orange)',
+                fontSize: '1.3rem'
+              }}>
+                Week {matchup.week_number || 'N/A'}
+                {matchup.is_playoff && (
+                  <span style={{
+                    marginLeft: '0.5rem',
+                    padding: '0.25rem 0.5rem',
+                    backgroundColor: '#FF9800',
+                    color: 'white',
+                    borderRadius: '4px',
+                    fontSize: '0.8rem',
+                    fontWeight: 'bold'
+                  }}>
+                    PLAYOFF
+                  </span>
+                )}
+              </h4>
+              <p style={{
+                margin: '0',
+                color: 'var(--dark-gray)',
+                fontSize: '1rem'
+              }}>
+                {matchup.week_date ? formatDate(matchup.week_date) : 'Date TBD'}
+              </p>
+            </div>
+
+            {/* Teams Display */}
+            <div style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: '2rem'
+            }}>
+              {/* User's Team (Left) */}
+              <div style={{
+                flex: 1,
+                textAlign: 'center',
+                padding: '1.5rem',
+                backgroundColor: 'white',
+                border: '2px solid var(--primary-orange)',
+                borderRadius: '12px',
+                boxShadow: '0 4px 8px rgba(0,0,0,0.1)'
+              }}>
+                <div style={{
+                  fontSize: '1.2rem',
+                  fontWeight: 'bold',
+                  color: 'var(--black)',
+                  marginBottom: '0.5rem'
+                }}>
+                  {matchup.user_team?.name || 'Your Team'}
+                </div>
+                <div style={{
+                  fontSize: '2rem',
+                  fontWeight: 'bold',
+                  color: 'var(--primary-orange)',
+                  marginBottom: '0.5rem'
+                }}>
+                  {(matchup.user_team?.points || 0).toFixed(1)}
+                </div>
+                <div style={{
+                  fontSize: '0.9rem',
+                  color: 'var(--dark-gray)'
+                }}>
+                  {matchup.user_team?.is_home ? '🏠 Home' : '✈️ Away'}
+                </div>
+              </div>
+
+              {/* VS Divider */}
+              <div style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '0.5rem'
+              }}>
+                <div style={{
+                  fontSize: '2rem',
+                  fontWeight: 'bold',
+                  color: 'var(--primary-orange)'
+                }}>
+                  VS
+                </div>
+                <div style={{
+                  fontSize: '0.8rem',
+                  color: 'var(--dark-gray)',
+                  textAlign: 'center'
+                }}>
+                  Fantasy Points
+                </div>
+              </div>
+
+              {/* Opponent Team (Right) */}
+              <div style={{
+                flex: 1,
+                textAlign: 'center',
+                padding: '1.5rem',
+                backgroundColor: 'white',
+                border: '2px solid var(--light-gray)',
+                borderRadius: '12px',
+                boxShadow: '0 4px 8px rgba(0,0,0,0.1)'
+              }}>
+                <div style={{
+                  fontSize: '1.2rem',
+                  fontWeight: 'bold',
+                  color: 'var(--black)',
+                  marginBottom: '0.5rem'
+                }}>
+                  {matchup.opponent_team?.name || 'Opponent'}
+                </div>
+                <div style={{
+                  fontSize: '2rem',
+                  fontWeight: 'bold',
+                  color: 'var(--dark-gray)',
+                  marginBottom: '0.5rem'
+                }}>
+                  {(matchup.opponent_team?.points || 0).toFixed(1)}
+                </div>
+                <div style={{
+                  fontSize: '0.9rem',
+                  color: 'var(--dark-gray)'
+                }}>
+                  {matchup.opponent_team?.is_home ? '🏠 Home' : '✈️ Away'}
+                </div>
+              </div>
+            </div>
+
+            {/* Match Status */}
+            <div style={{
+              textAlign: 'center',
+              marginTop: '1.5rem',
+              padding: '1rem',
+              backgroundColor: '#E8F5E9',
+              border: '1px solid #4CAF50',
+              borderRadius: '8px'
+            }}>
+              <p style={{
+                margin: '0',
+                color: '#2E7D32',
+                fontSize: '0.9rem'
+              }}>
+                📊 Points are calculated based on your team's player performance in real matches
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Matchup;

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -3,67 +3,48 @@ import { useNavigate } from 'react-router-dom';
 
 const NavigationBar = ({ 
   leagueData, 
+  tournamentData,
   isAdmin, 
   draftComplete, 
   draftStatus,
   activeTab, 
   setActiveTab, 
-  onStartDraft 
+  onStartDraft,
+  chatUnreadCount = 0
 }) => {
   const navigate = useNavigate();
   
   return (
-    <div className="card" style={{ marginBottom: '2rem' }}>
-      {/* Breadcrumb Navigation */}
-      <div style={{ 
-        padding: '0.5rem 0', 
-        borderBottom: '1px solid #eee', 
-        marginBottom: '1rem',
-        fontSize: '0.9rem',
-        color: '#666'
-      }}>
-        <span 
-          onClick={() => navigate('/my-leagues')}
-          style={{ 
-            cursor: 'pointer', 
-            color: 'var(--primary-orange)',
-            textDecoration: 'underline'
-          }}
-        >
-          My Leagues
-        </span>
-        <span style={{ margin: '0 0.5rem' }}>→</span>
-        <span style={{ color: 'var(--black)', fontWeight: '500' }}>
-          {leagueData?.name || 'Fantasy League'}
-        </span>
-      </div>
-      
+    <div className="card" style={{ marginBottom: '24px' }}>
       <div style={{ 
         display: 'flex', 
         justifyContent: 'space-between', 
         alignItems: 'center',
-        padding: '1rem 0'
+        padding: '16px 0'
       }}>
         <div>
-          <h2 style={{ margin: 0, color: 'var(--primary-orange)' }}>
+          <h2 style={{ 
+            margin: 0, 
+            color: 'var(--databricks-blue)',
+            fontSize: '24px',
+            fontWeight: '600'
+          }}>
             {leagueData?.name || 'Fantasy League'}
           </h2>
-          <p style={{ margin: '0.5rem 0 0 0', color: '#666' }}>
-            {leagueData?.description || 'A competitive fantasy rugby league'}
+          <p style={{ 
+            margin: '4px 0 0 0', 
+            color: 'var(--neutral-600)',
+            fontSize: '14px'
+          }}>
+            {tournamentData?.name ? `A ${tournamentData.name} Fantasy game` : (leagueData?.description || 'A Fantasy Rugby game')}
           </p>
         </div>
         
-        <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
           <button 
             onClick={() => navigate('/my-leagues')}
-            style={{ 
-              backgroundColor: 'transparent', 
-              border: '1px solid var(--primary-orange)',
-              padding: '0.5rem 1rem',
-              borderRadius: '4px',
-              color: 'var(--primary-orange)',
-              cursor: 'pointer'
-            }}
+            className="btn btn-outline btn-small"
+            style={{ fontSize: '14px' }}
           >
             ← Back to My Leagues
           </button>
@@ -73,15 +54,7 @@ const NavigationBar = ({
                 <button 
                   onClick={onStartDraft}
                   className="btn btn-primary"
-                  style={{ 
-                    backgroundColor: 'var(--primary-orange)', 
-                    border: 'none',
-                    padding: '0.5rem 1rem',
-                    borderRadius: '4px',
-                    color: 'white',
-                    cursor: 'pointer',
-                    fontWeight: 'bold'
-                  }}
+                  style={{ fontSize: '14px' }}
                 >
                   🚀 Start Draft
                 </button>
@@ -91,13 +64,7 @@ const NavigationBar = ({
                   onClick={onStartDraft}
                   className="btn btn-primary"
                   style={{ 
-                    backgroundColor: 'var(--primary-orange)', 
-                    border: 'none',
-                    padding: '0.5rem 1rem',
-                    borderRadius: '4px',
-                    color: 'white',
-                    cursor: 'pointer',
-                    fontWeight: 'bold',
+                    fontSize: '14px',
                     animation: !isAdmin ? 'pulse 2s infinite' : 'none'
                   }}
                 >
@@ -111,61 +78,140 @@ const NavigationBar = ({
       
       <div style={{ 
         display: 'flex', 
-        gap: '1rem', 
-        borderTop: '1px solid #eee', 
-        paddingTop: '1rem' 
+        justifyContent: 'center',
+        gap: '12px', 
+        borderTop: '1px solid var(--neutral-200)', 
+        paddingTop: '16px' 
       }}>
         <button
           onClick={() => setActiveTab('league')}
+          className="btn"
           style={{
-            padding: '0.5rem 1rem',
-            border: 'none',
-            backgroundColor: activeTab === 'league' ? 'var(--primary-orange)' : 'transparent',
-            color: activeTab === 'league' ? 'white' : 'var(--primary-orange)',
-            cursor: 'pointer',
-            borderRadius: '4px'
+            backgroundColor: activeTab === 'league' ? 'var(--databricks-blue)' : 'transparent',
+            color: activeTab === 'league' ? 'white' : 'var(--neutral-700)',
+            border: activeTab === 'league' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+            fontSize: '14px',
+            fontWeight: '500',
+            width: '160px'
           }}
         >
           League Table
         </button>
         <button
           onClick={() => setActiveTab('my-team')}
+          className="btn"
           style={{
-            padding: '0.5rem 1rem',
-            border: 'none',
-            backgroundColor: activeTab === 'my-team' ? 'var(--primary-orange)' : 'transparent',
-            color: activeTab === 'my-team' ? 'white' : 'var(--primary-orange)',
-            cursor: 'pointer',
-            borderRadius: '4px'
+            backgroundColor: activeTab === 'my-team' ? 'var(--databricks-blue)' : 'transparent',
+            color: activeTab === 'my-team' ? 'white' : 'var(--neutral-700)',
+            border: activeTab === 'my-team' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+            fontSize: '14px',
+            fontWeight: '500',
+            width: '160px'
           }}
         >
           My Team
         </button>
+        {draftComplete && (
+          <button
+            onClick={() => setActiveTab('waivers')}
+            className="btn"
+            style={{
+              backgroundColor: activeTab === 'waivers' ? 'var(--databricks-blue)' : 'transparent',
+              color: activeTab === 'waivers' ? 'white' : 'var(--neutral-700)',
+              border: activeTab === 'waivers' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+              fontSize: '14px',
+              fontWeight: '500',
+              width: '160px'
+            }}
+          >
+            Waivers
+          </button>
+        )}
+        {draftComplete && (
+          <button
+            onClick={() => setActiveTab('trade')}
+            className="btn"
+            style={{
+              backgroundColor: activeTab === 'trade' ? 'var(--databricks-blue)' : 'transparent',
+              color: activeTab === 'trade' ? 'white' : 'var(--neutral-700)',
+              border: activeTab === 'trade' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+              fontSize: '14px',
+              fontWeight: '500',
+              width: '160px'
+            }}
+          >
+            Trade
+          </button>
+        )}
+        {draftComplete && (
+          <button
+            onClick={() => setActiveTab('fixtures')}
+            className="btn"
+            style={{
+              backgroundColor: activeTab === 'fixtures' ? 'var(--databricks-blue)' : 'transparent',
+              color: activeTab === 'fixtures' ? 'white' : 'var(--neutral-700)',
+              border: activeTab === 'fixtures' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+              fontSize: '14px',
+              fontWeight: '500',
+              width: '160px'
+            }}
+          >
+            Fixtures
+          </button>
+        )}
+        {draftComplete && (
+          <button
+            onClick={() => setActiveTab('matchup')}
+            className="btn"
+            style={{
+              backgroundColor: activeTab === 'matchup' ? 'var(--databricks-blue)' : 'transparent',
+              color: activeTab === 'matchup' ? 'white' : 'var(--neutral-700)',
+              border: activeTab === 'matchup' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+              fontSize: '14px',
+              fontWeight: '500',
+              width: '160px'
+            }}
+          >
+            Matchup
+          </button>
+        )}
         <button
-          onClick={() => setActiveTab('waivers')}
+          onClick={() => setActiveTab('chat')}
+          className="btn"
           style={{
-            padding: '0.5rem 1rem',
-            border: 'none',
-            backgroundColor: activeTab === 'waivers' ? 'var(--primary-orange)' : 'transparent',
-            color: activeTab === 'waivers' ? 'white' : 'var(--primary-orange)',
-            cursor: 'pointer',
-            borderRadius: '4px'
+            backgroundColor: activeTab === 'chat' ? 'var(--databricks-blue)' : 'transparent',
+            color: activeTab === 'chat' ? 'white' : 'var(--neutral-700)',
+            border: activeTab === 'chat' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+            fontSize: '14px',
+            fontWeight: '500',
+            width: '160px',
+            position: 'relative'
           }}
         >
-          Waivers
-        </button>
-        <button
-          onClick={() => setActiveTab('trade')}
-          style={{
-            padding: '0.5rem 1rem',
-            border: 'none',
-            backgroundColor: activeTab === 'trade' ? 'var(--primary-orange)' : 'transparent',
-            color: activeTab === 'trade' ? 'white' : 'var(--primary-orange)',
-            cursor: 'pointer',
-            borderRadius: '4px'
-          }}
-        >
-          Trade
+          💬 Chat
+          {chatUnreadCount > 0 && (
+            <span
+              style={{
+                position: 'absolute',
+                top: '-8px',
+                right: '-8px',
+                backgroundColor: '#ff4444',
+                color: 'white',
+                borderRadius: '50%',
+                width: '20px',
+                height: '20px',
+                fontSize: '12px',
+                fontWeight: 'bold',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: '20px',
+                padding: '0 4px'
+              }}
+            >
+              {chatUnreadCount > 99 ? '99+' : chatUnreadCount}
+            </span>
+          )}
         </button>
       </div>
     </div>

--- a/frontend/src/components/SwapModal.js
+++ b/frontend/src/components/SwapModal.js
@@ -11,8 +11,9 @@ const SwapModal = ({
   if (!showSwapModal || !swapData) return null;
 
   const getPlayerName = (playerId) => {
+    if (!playerId) return 'Unknown Player';
     if (!rugbyPlayers) return `Player ${playerId}`;
-    const player = rugbyPlayers.find(p => p.id.toString() === playerId.toString());
+    const player = rugbyPlayers.find(p => p.id && p.id.toString() === playerId.toString());
     return player ? player.name : `Player ${playerId}`;
   };
 
@@ -55,13 +56,13 @@ const SwapModal = ({
             color: 'var(--dark-gray)',
             fontWeight: '600'
           }}>
-            Move to Starting:
+            {swapData.targetPosition === 'Bench' ? 'Move to Bench:' : 'Move to Starting:'}
           </p>
           <div style={{
             padding: '1rem',
-            backgroundColor: '#E8F5E9',
+            backgroundColor: swapData.targetPosition === 'Bench' ? '#FFEBEE' : '#E8F5E9',
             borderRadius: '8px',
-            border: '2px solid #2ECC71',
+            border: swapData.targetPosition === 'Bench' ? '2px solid #C0392B' : '2px solid #2ECC71',
             fontWeight: 'bold',
             fontSize: '1.1rem'
           }}>
@@ -84,7 +85,7 @@ const SwapModal = ({
             color: 'var(--dark-gray)',
             fontWeight: '600'
           }}>
-            Select which player to move to Bench:
+            {swapData.targetPosition === 'Bench' ? 'Select which player to move to Starting:' : 'Select which player to move to Bench:'}
           </p>
           <div style={{ 
             maxHeight: '250px', 
@@ -104,9 +105,9 @@ const SwapModal = ({
                     }}
                     style={{
                       padding: '1rem',
-                      backgroundColor: isSelected ? '#FFEBEE' : 'white',
+                      backgroundColor: isSelected ? (swapData.targetPosition === 'Bench' ? '#E8F5E9' : '#FFEBEE') : 'white',
                       borderRadius: '8px',
-                      border: isSelected ? '2px solid #C0392B' : '2px solid #e0e0e0',
+                      border: isSelected ? (swapData.targetPosition === 'Bench' ? '2px solid #2ECC71' : '2px solid #C0392B') : '2px solid #e0e0e0',
                       cursor: 'pointer',
                       transition: 'all 0.2s ease',
                       position: 'relative'
@@ -118,13 +119,13 @@ const SwapModal = ({
                       marginBottom: '0.25rem',
                       color: isSelected ? '#C0392B' : 'var(--black)'
                     }}>
-                      ⬇️ {getPlayerName(currentPlayer.player_id) || currentPlayer.name}
+                      ⬇️ {getPlayerName(currentPlayer.id) || currentPlayer.name}
                     </div>
                     <div style={{ 
                       fontSize: '0.9rem',
                       color: 'var(--dark-gray)'
                     }}>
-                      Currently: {currentPlayer.fantasy_position}
+                      {currentPlayer.fantasy_position}
                     </div>
                     {isSelected && (
                       <div style={{

--- a/frontend/src/components/Trade.js
+++ b/frontend/src/components/Trade.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { leaguesAPI, teamsAPI } from '../services/api';
 
-const Trade = ({ selectedTeam, rugbyPlayers, teamPlayers, user, leagueId, allTeams }) => {
+const Trade = ({ selectedTeam, rugbyPlayers, teamPlayers, user, leagueId, allTeams, onLoadRugbyPlayers, isActive }) => {
   const [activeTradeTab, setActiveTradeTab] = useState('propose'); // 'propose' or 'received'
   const [selectedTradePartner, setSelectedTradePartner] = useState(null);
   const [mySelectedPlayers, setMySelectedPlayers] = useState([]);
@@ -9,6 +9,13 @@ const Trade = ({ selectedTeam, rugbyPlayers, teamPlayers, user, leagueId, allTea
   const [tradeProposals, setTradeProposals] = useState([]);
   const [partnerPlayers, setPartnerPlayers] = useState([]);
   const [loadingPartnerPlayers, setLoadingPartnerPlayers] = useState(false);
+
+  // Load rugby players when component mounts
+  useEffect(() => {
+    if (onLoadRugbyPlayers && rugbyPlayers.length === 0) {
+      onLoadRugbyPlayers();
+    }
+  }, [onLoadRugbyPlayers, rugbyPlayers.length]);
 
   const loadTradeProposals = useCallback(async () => {
     try {
@@ -20,10 +27,10 @@ const Trade = ({ selectedTeam, rugbyPlayers, teamPlayers, user, leagueId, allTea
   }, [leagueId]);
 
   useEffect(() => {
-    if (leagueId) {
+    if (leagueId && isActive) {
       loadTradeProposals();
     }
-  }, [leagueId, loadTradeProposals]);
+  }, [leagueId, isActive, loadTradeProposals]);
 
   // Load partner's players when a trade partner is selected
   useEffect(() => {
@@ -143,42 +150,54 @@ const Trade = ({ selectedTeam, rugbyPlayers, teamPlayers, user, leagueId, allTea
 
   return (
     <div className="card">
-      <h3 style={{ marginBottom: '1.5rem', color: 'var(--primary-orange)' }}>
-        🔄 Trade Center
-      </h3>
+      <div className="card-header">
+        <h3 style={{ 
+          margin: 0, 
+          color: 'var(--databricks-blue)',
+          fontSize: '20px',
+          fontWeight: '600'
+        }}>
+          🔄 Trade Center
+        </h3>
+        <p style={{
+          margin: '4px 0 0 0',
+          color: 'var(--neutral-600)',
+          fontSize: '14px'
+        }}>
+          Propose and manage player trades with other teams
+        </p>
+      </div>
 
       {/* Trade Tabs */}
       <div style={{ 
         display: 'flex', 
-        gap: '1rem', 
-        marginBottom: '2rem',
-        borderBottom: '2px solid var(--light-gray)',
-        paddingBottom: '0.5rem'
+        gap: '4px', 
+        marginBottom: '24px',
+        borderBottom: '1px solid var(--neutral-200)',
+        paddingBottom: '16px'
       }}>
         <button
           onClick={() => setActiveTradeTab('propose')}
+          className="btn"
           style={{
-            padding: '0.5rem 1.5rem',
-            border: 'none',
-            backgroundColor: activeTradeTab === 'propose' ? 'var(--primary-orange)' : 'transparent',
-            color: activeTradeTab === 'propose' ? 'white' : 'var(--dark-gray)',
-            cursor: 'pointer',
-            borderRadius: '4px',
-            fontWeight: activeTradeTab === 'propose' ? 'bold' : 'normal'
+            backgroundColor: activeTradeTab === 'propose' ? 'var(--databricks-blue)' : 'transparent',
+            color: activeTradeTab === 'propose' ? 'white' : 'var(--neutral-700)',
+            border: activeTradeTab === 'propose' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+            fontSize: '14px',
+            fontWeight: '500'
           }}
         >
           📤 Propose Trade
         </button>
         <button
           onClick={() => setActiveTradeTab('received')}
+          className="btn"
           style={{
-            padding: '0.5rem 1.5rem',
-            border: 'none',
-            backgroundColor: activeTradeTab === 'received' ? 'var(--primary-orange)' : 'transparent',
-            color: activeTradeTab === 'received' ? 'white' : 'var(--dark-gray)',
-            cursor: 'pointer',
-            borderRadius: '4px',
-            fontWeight: activeTradeTab === 'received' ? 'bold' : 'normal'
+            backgroundColor: activeTradeTab === 'received' ? 'var(--databricks-blue)' : 'transparent',
+            color: activeTradeTab === 'received' ? 'white' : 'var(--neutral-700)',
+            border: activeTradeTab === 'received' ? '1px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+            fontSize: '14px',
+            fontWeight: '500'
           }}
         >
           📥 Received Proposals {tradeProposals.length > 0 && `(${tradeProposals.length})`}

--- a/frontend/src/components/draft/DraftControls.js
+++ b/frontend/src/components/draft/DraftControls.js
@@ -5,6 +5,7 @@ const DraftControls = ({
   isAdmin, 
   onStartDraft, 
   onShuffleDraft,
+  onViewDraftOrder,
   disabled 
 }) => {
   if (draftStarted) {
@@ -15,7 +16,7 @@ const DraftControls = ({
     <div className="card" style={{ marginBottom: '2rem', textAlign: 'center' }}>
       <h2 style={{ marginBottom: '1rem' }}>Draft Controls</h2>
       {isAdmin ? (
-        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
           <button
             onClick={onStartDraft}
             disabled={disabled}
@@ -49,6 +50,21 @@ const DraftControls = ({
             }}
           >
             Shuffle Draft Order
+          </button>
+          <button
+            onClick={onViewDraftOrder}
+            style={{
+              backgroundColor: 'var(--databricks-blue)',
+              color: 'white',
+              border: 'none',
+              padding: '1rem 2rem',
+              borderRadius: '6px',
+              fontSize: '1.2rem',
+              fontWeight: 'bold',
+              cursor: 'pointer'
+            }}
+          >
+            📊 View Draft Order
           </button>
         </div>
       ) : (

--- a/frontend/src/components/draft/DraftHeader.js
+++ b/frontend/src/components/draft/DraftHeader.js
@@ -37,9 +37,25 @@ const DraftHeader = ({ leagueData, teams, onBackToLeague }) => {
       {/* Draft Title */}
       <div className="card" style={{ marginBottom: '2rem' }}>
         <div style={{ textAlign: 'center' }}>
-          <h1 style={{ margin: 0, color: 'var(--black)', fontSize: '2.5rem' }}>
-            🏉 Player Draft
-          </h1>
+          <div style={{ 
+            display: 'flex', 
+            alignItems: 'center', 
+            justifyContent: 'center', 
+            gap: '12px',
+            marginBottom: '8px'
+          }}>
+            <img 
+              src="/rugby-ball.png" 
+              alt="Rugby Ball" 
+              style={{ 
+                width: '40px', 
+                height: '40px' 
+              }} 
+            />
+            <h1 style={{ margin: 0, color: 'var(--black)', fontSize: '2.5rem' }}>
+              Player Draft
+            </h1>
+          </div>
           <p style={{ 
             margin: '0.5rem 0 0 0', 
             color: 'var(--dark-gray)',

--- a/frontend/src/components/draft/DraftOrderView.js
+++ b/frontend/src/components/draft/DraftOrderView.js
@@ -1,0 +1,141 @@
+import React from 'react';
+
+const DraftOrderView = ({ teams, currentTeam, selectedPlayers, user }) => {
+  return (
+    <div style={{ 
+      display: 'grid', 
+      gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+      gap: '1.5rem'
+    }}>
+      {teams.map((team, index) => {
+        const isCurrentTurn = currentTeam?.id === team.id;
+        const teamPlayers = selectedPlayers[team.id] || [];
+        const playerCount = teamPlayers.length;
+        const teamUserId = team.user_id || team.team_owner_user_id;
+        const isUserTeam = user && teamUserId === user.id.toString();
+        
+        return (
+          <div
+            key={team.id}
+            className="card"
+            style={{
+              border: isCurrentTurn ? '3px solid var(--databricks-blue)' : '1px solid var(--neutral-200)',
+              backgroundColor: isCurrentTurn ? 'var(--neutral-50)' : 'white',
+              transition: 'all 0.3s ease',
+              transform: isCurrentTurn ? 'scale(1.02)' : 'scale(1)',
+              boxShadow: isCurrentTurn ? '0 4px 12px rgba(0, 123, 255, 0.2)' : '0 2px 8px rgba(0, 0, 0, 0.1)'
+            }}
+          >
+            <div style={{ 
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: '1rem'
+            }}>
+              <div>
+                <h3 style={{ 
+                  margin: '0 0 0.25rem 0',
+                  color: isCurrentTurn ? 'var(--databricks-blue)' : 'var(--black)',
+                  fontSize: '1.2rem',
+                  fontWeight: '600'
+                }}>
+                  {team.team_name} {isUserTeam && '⭐'}
+                </h3>
+                <p style={{ 
+                  margin: 0,
+                  color: 'var(--neutral-600)',
+                  fontSize: '0.9rem'
+                }}>
+                  {playerCount}/15 players selected
+                </p>
+              </div>
+              {isCurrentTurn && (
+                <div style={{
+                  fontSize: '1.5rem',
+                  animation: 'pulse 1.5s infinite'
+                }}>
+                  👉
+                </div>
+              )}
+            </div>
+            
+            {/* Progress bar */}
+            <div style={{
+              width: '100%',
+              height: '8px',
+              backgroundColor: 'var(--neutral-200)',
+              borderRadius: '4px',
+              overflow: 'hidden',
+              marginBottom: '1rem'
+            }}>
+              <div style={{
+                width: `${(playerCount / 15) * 100}%`,
+                height: '100%',
+                backgroundColor: isCurrentTurn ? 'var(--databricks-blue)' : 'var(--primary-orange)',
+                transition: 'width 0.3s ease'
+              }} />
+            </div>
+
+            {/* Selected Players List */}
+            {teamPlayers.length > 0 ? (
+              <div style={{ 
+                maxHeight: '200px', 
+                overflowY: 'auto',
+                borderTop: '1px solid var(--neutral-200)',
+                paddingTop: '1rem'
+              }}>
+                {teamPlayers.map((player, playerIndex) => (
+                  <div 
+                    key={player.id}
+                    style={{
+                      padding: '0.75rem',
+                      marginBottom: '0.5rem',
+                      backgroundColor: player.autoPicked ? '#FFF3CD' : 'var(--neutral-50)',
+                      borderRadius: '6px',
+                      fontSize: '0.9rem',
+                      borderLeft: player.autoPicked ? '3px solid #FFC107' : '3px solid var(--databricks-blue)'
+                    }}
+                  >
+                    <div style={{ 
+                      fontWeight: '600',
+                      color: 'var(--black)',
+                      marginBottom: '0.25rem'
+                    }}>
+                      {playerIndex + 1}. {player.name} {player.autoPicked && '🤖'}
+                    </div>
+                    <div style={{ 
+                      fontSize: '0.8rem',
+                      color: 'var(--neutral-600)'
+                    }}>
+                      {player.fantasy_position} - {player.team}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div style={{ 
+                textAlign: 'center',
+                padding: '2rem 1rem',
+                color: 'var(--neutral-500)',
+                fontStyle: 'italic'
+              }}>
+                No players selected yet
+              </div>
+            )}
+          </div>
+        );
+      })}
+      
+      <style>
+        {`
+          @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+          }
+        `}
+      </style>
+    </div>
+  );
+};
+
+export default DraftOrderView;

--- a/frontend/src/components/draft/DraftSectionMenu.js
+++ b/frontend/src/components/draft/DraftSectionMenu.js
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+
+const DraftSectionMenu = ({ activeView, setActiveView }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const menuOptions = [
+    { key: 'players', label: 'Available Players' },
+    { key: 'order', label: 'Draft Order' }
+  ];
+
+  const handleOptionClick = (option) => {
+    setActiveView(option.key);
+    setIsOpen(false);
+  };
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      {/* Burger Menu Button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '8px',
+          borderRadius: '4px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '3px',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '32px',
+          height: '32px',
+          outline: 'none'
+        }}
+        onMouseEnter={(e) => e.target.style.backgroundColor = 'var(--neutral-100)'}
+        onMouseLeave={(e) => e.target.style.backgroundColor = 'transparent'}
+      >
+        <div style={{ 
+          width: '18px', 
+          height: '2px', 
+          backgroundColor: 'var(--neutral-600)',
+          borderRadius: '1px'
+        }}></div>
+        <div style={{ 
+          width: '18px', 
+          height: '2px', 
+          backgroundColor: 'var(--neutral-600)',
+          borderRadius: '1px'
+        }}></div>
+        <div style={{ 
+          width: '18px', 
+          height: '2px', 
+          backgroundColor: 'var(--neutral-600)',
+          borderRadius: '1px'
+        }}></div>
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div style={{
+          position: 'absolute',
+          top: '100%',
+          right: '0',
+          backgroundColor: 'white',
+          border: '1px solid var(--neutral-200)',
+          borderRadius: '8px',
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+          zIndex: 1000,
+          minWidth: '200px',
+          marginTop: '4px'
+        }}>
+                      {menuOptions.map((option) => (
+            <button
+              key={option.key}
+              onClick={() => handleOptionClick(option)}
+              style={{
+                width: '100%',
+                padding: '12px 16px',
+                border: 'none',
+                background: activeView === option.key ? 'var(--databricks-light-blue)' : 'transparent',
+                color: activeView === option.key ? 'var(--databricks-blue)' : 'var(--neutral-700)',
+                textAlign: 'left',
+                cursor: 'pointer',
+                fontSize: '14px',
+                fontWeight: activeView === option.key ? '600' : '400',
+                borderBottom: '1px solid var(--neutral-100)'
+              }}
+              onMouseEnter={(e) => {
+                if (activeView !== option.key) {
+                  e.target.style.backgroundColor = 'var(--neutral-50)';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (activeView !== option.key) {
+                  e.target.style.backgroundColor = 'transparent';
+                }
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Click outside to close */}
+      {isOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 999
+          }}
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DraftSectionMenu;

--- a/frontend/src/components/draft/DraftStatus.js
+++ b/frontend/src/components/draft/DraftStatus.js
@@ -3,8 +3,9 @@ import DraftTimer from './DraftTimer';
 
 const DraftStatus = ({ 
   draftStarted, 
+  draftPaused,
   currentPick, 
-  currentTeam, 
+  currentTeam,
   timeRemaining,
   totalPicks,
   user,
@@ -41,17 +42,17 @@ const DraftStatus = ({
         </h2>
         <p style={{ 
           margin: 0,
-          color: isCurrentTurn ? 'var(--primary-orange)' : 'var(--dark-gray)',
+          color: draftPaused ? '#dc3545' : (isCurrentTurn ? 'var(--primary-orange)' : 'var(--dark-gray)'),
           fontSize: '1.2rem',
-          fontWeight: isCurrentTurn ? 'bold' : 'normal'
+          fontWeight: (draftPaused || isCurrentTurn) ? 'bold' : 'normal'
         }}>
-          {isCurrentTurn ? "It's your turn!" : `Waiting for ${currentTeam?.team_name}...`}
+          {draftPaused ? "⏸️ Draft is paused" : (isCurrentTurn ? "It's your turn!" : `Waiting for ${currentTeam?.team_name}...`)}
         </p>
       </div>
       
-      <DraftTimer timeRemaining={timeRemaining} />
+      <DraftTimer timeRemaining={timeRemaining} draftPaused={draftPaused} />
       
-      {isCurrentTurn && (
+      {isCurrentTurn && !draftPaused && (
         <div style={{
           marginTop: '1rem',
           padding: '1rem',
@@ -62,6 +63,21 @@ const DraftStatus = ({
           fontWeight: 'bold'
         }}>
           Select a player from the list below
+        </div>
+      )}
+
+      {draftPaused && (
+        <div style={{
+          marginTop: '1rem',
+          padding: '1rem',
+          backgroundColor: '#f8d7da',
+          borderRadius: '6px',
+          textAlign: 'center',
+          color: '#721c24',
+          fontWeight: 'bold',
+          border: '1px solid #f5c6cb'
+        }}>
+          ⏸️ Draft is paused. The admin will resume when ready.
         </div>
       )}
     </div>

--- a/frontend/src/components/draft/DraftTimer.js
+++ b/frontend/src/components/draft/DraftTimer.js
@@ -1,8 +1,24 @@
 import React from 'react';
 
-const DraftTimer = ({ timeRemaining }) => {
+const DraftTimer = ({ timeRemaining, draftPaused }) => {
   const minutes = Math.floor(timeRemaining / 60);
   const seconds = timeRemaining % 60;
+  
+  if (draftPaused) {
+    return (
+      <div style={{ 
+        textAlign: 'center',
+        padding: '1rem',
+        backgroundColor: '#6c757d',
+        color: 'white',
+        borderRadius: '8px',
+        fontSize: '1.5rem',
+        fontWeight: 'bold'
+      }}>
+        ⏸️ Draft Paused
+      </div>
+    );
+  }
   
   return (
     <div style={{ 

--- a/frontend/src/components/draft/PlayerCard.js
+++ b/frontend/src/components/draft/PlayerCard.js
@@ -58,6 +58,29 @@ const PlayerCard = ({ player, onSelect, isSelected, disabled }) => {
           <p style={{ margin: '0.5rem 0 0 0', color: 'var(--dark-gray)', fontSize: '0.9rem' }}>
             Team: {player.team}
           </p>
+          {/* Fantasy Points Display */}
+          {player.fantasy_points_per_game !== undefined && (
+            <div style={{ marginTop: '0.75rem', padding: '0.5rem', backgroundColor: '#f8f9fa', borderRadius: '6px' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.25rem' }}>
+                <span style={{ fontSize: '0.85rem', color: 'var(--dark-gray)' }}>Fantasy Points/Game:</span>
+                <span style={{ fontSize: '0.85rem', fontWeight: 'bold', color: 'var(--primary-orange)' }}>
+                  {player.fantasy_points_per_game}
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.25rem' }}>
+                <span style={{ fontSize: '0.85rem', color: 'var(--dark-gray)' }}>Fantasy Points/Min:</span>
+                <span style={{ fontSize: '0.85rem', fontWeight: 'bold', color: 'var(--primary-orange)' }}>
+                  {player.fantasy_points_per_minute}
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ fontSize: '0.85rem', color: 'var(--dark-gray)' }}>Total Fantasy Points:</span>
+                <span style={{ fontSize: '0.85rem', fontWeight: 'bold', color: 'var(--primary-orange)' }}>
+                  {player.total_fantasy_points}
+                </span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/draft/PlayerConfirmModal.js
+++ b/frontend/src/components/draft/PlayerConfirmModal.js
@@ -57,6 +57,42 @@ const PlayerConfirmModal = ({ player, onConfirm, onCancel }) => {
           }}>
             <strong>Team:</strong> {player.team}
           </p>
+          {/* Fantasy Points Display */}
+          {player.fantasy_points_per_game !== undefined && (
+            <div style={{ 
+              marginTop: '1rem', 
+              padding: '1rem', 
+              backgroundColor: 'white', 
+              borderRadius: '6px',
+              border: '1px solid var(--light-gray)'
+            }}>
+              <h4 style={{ 
+                margin: '0 0 0.75rem 0', 
+                color: 'var(--black)',
+                fontSize: '1.2rem'
+              }}>
+                Fantasy Points
+              </h4>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+                <span style={{ fontSize: '1rem', color: 'var(--dark-gray)' }}>Points/Game:</span>
+                <span style={{ fontSize: '1rem', fontWeight: 'bold', color: 'var(--primary-orange)' }}>
+                  {player.fantasy_points_per_game}
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+                <span style={{ fontSize: '1rem', color: 'var(--dark-gray)' }}>Points/Minute:</span>
+                <span style={{ fontSize: '1rem', fontWeight: 'bold', color: 'var(--primary-orange)' }}>
+                  {player.fantasy_points_per_minute}
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ fontSize: '1rem', color: 'var(--dark-gray)' }}>Total Points:</span>
+                <span style={{ fontSize: '1rem', fontWeight: 'bold', color: 'var(--primary-orange)' }}>
+                  {player.total_fantasy_points}
+                </span>
+              </div>
+            </div>
+          )}
         </div>
 
         <p style={{ 

--- a/frontend/src/components/draft/index.js
+++ b/frontend/src/components/draft/index.js
@@ -8,4 +8,6 @@ export { default as PlayerList } from './PlayerList';
 export { default as TeamRoster } from './TeamRoster';
 export { default as PlayerConfirmModal } from './PlayerConfirmModal';
 export { default as MyTeamView } from './MyTeamView';
+export { default as DraftSectionMenu } from './DraftSectionMenu';
+export { default as DraftOrderView } from './DraftOrderView';
 

--- a/frontend/src/hooks/useDraftData.js
+++ b/frontend/src/hooks/useDraftData.js
@@ -37,13 +37,18 @@ export const useDraftData = (leagueId, user, authLoading) => {
         }
         
         // Fetch teams in the league
-        const allTeams = await teamsAPI.getTeams();
-        const teamsData = allTeams.filter(team => team.league_id === leagueId);
+        const teamsData = await teamsAPI.getTeamsByLeague(leagueId);
         setTeams(teamsData || []);
         
-        // Fetch rugby players
-        const playersData = await rugbyPlayersAPI.getPlayers();
-        setPlayers(playersData || []);
+            // Fetch rugby players filtered by tournament
+            const tournamentId = league?.tournament_id;
+            console.log('DEBUG: Fetching players for tournament:', tournamentId);
+            const playersData = await rugbyPlayersAPI.getPlayers(tournamentId);
+            console.log('DEBUG: Players data received:', playersData?.length, 'players');
+            if (playersData && playersData.length > 0) {
+              console.log('DEBUG: First player data:', playersData[0]);
+            }
+            setPlayers(playersData || []);
         
         // Check if current user is the admin of this league
         if (league && user && user.id) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  font-family: 'Inter', 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -24,7 +24,7 @@ code {
 }
 
 .header {
-  background-color: #1e3a8a;
+  background-color: #4169E1;
   color: white;
   padding: 20px 0;
   text-align: center;
@@ -52,7 +52,7 @@ code {
 
 .team-card h3 {
   margin-top: 0;
-  color: #1e3a8a;
+  color: #4169E1;
 }
 
 .player-list {
@@ -79,7 +79,7 @@ code {
 
 .player-name {
   font-weight: bold;
-  color: #1e3a8a;
+  color: #4169E1;
 }
 
 .player-position {
@@ -93,7 +93,7 @@ code {
 }
 
 .btn {
-  background-color: #1e3a8a;
+  background-color: #4169E1;
   color: white;
   border: none;
   padding: 10px 20px;
@@ -119,7 +119,7 @@ code {
   display: block;
   margin-bottom: 5px;
   font-weight: bold;
-  color: #1e3a8a;
+  color: #4169E1;
 }
 
 .form-group input,
@@ -134,6 +134,6 @@ code {
 .form-group input:focus,
 .form-group select:focus {
   outline: none;
-  border-color: #1e3a8a;
-  box-shadow: 0 0 0 2px rgba(30, 58, 138, 0.2);
+  border-color: #4169E1;
+  box-shadow: 0 0 0 2px rgba(65, 105, 225, 0.2);
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,9 +5,7 @@ import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <App />
 );
 
 


### PR DESCRIPTION
- Add automatic fixture generation when users join leagues
- Create matchweek views for tournament availability, fixtures, and matchups
- Add Fixtures and Matchup components with team vs team display
- Hide post-draft tabs (Waivers, Trade, Fixtures, Matchup) until draft complete
- Add automatic redirection from post-draft tabs when draft not complete
- Fix Matchup component error handling with proper null checks
- Remove manual fixture generation in favor of automatic system
- Update NavigationBar and LeagueDashboard for conditional tab display